### PR TITLE
Set Headers['Reply-To'] to data.replyTo.

### DIFF
--- a/library.js
+++ b/library.js
@@ -39,7 +39,10 @@ Emailer.send = function(data, callback) {
 		'Html-part': data.html,
 		'Recipients': [{
 			'Email': data.to
-		}]
+		}],
+		'Headers': {
+			'Reply-To': data.replyTo
+		}
 	};
 
 	sendEmail


### PR DESCRIPTION
Allow setting Reply-To address according to data.replyTo.
For example, https://github.com/MinecraftForgeFrance/nodebb-plugin-contact-page uses data.replyTo to specify the Reply-To address.